### PR TITLE
Add Option for JSON output

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,14 +30,14 @@ Well, Spoofy is different and here is why:
 
 ```console
 Usage:
-    ./spoofy.py -d [DOMAIN] -o [stdout or xls] -t [NUMBER_OF_THREADS]
+    ./spoofy.py -d [DOMAIN] -o [stdout, json or xls] -t [NUMBER_OF_THREADS]
     OR
-    ./spoofy.py -iL [DOMAIN_LIST] -o [stdout or xls] -t [NUMBER_OF_THREADS]
+    ./spoofy.py -iL [DOMAIN_LIST] -o [stdout, json or xls] -t [NUMBER_OF_THREADS]
 
 Options:
     -d  : Process a single domain.
     -iL : Provide a file containing a list of domains to process.
-    -o  : Specify the output format: stdout (default) or xls.
+    -o  : Specify the output format: stdout (optionally as json) or xls (default: stdout).
     -t  : Set the number of threads to use (default: 4).
 
 Examples:

--- a/modules/report.py
+++ b/modules/report.py
@@ -2,6 +2,7 @@
 
 import os
 import pandas as pd
+import json
 from colorama import init, Fore, Style
 
 # Initialize colorama
@@ -20,6 +21,10 @@ def output_message(symbol, message, level="info"):
     }
     color = colors.get(level, Fore.WHITE + Style.BRIGHT)
     print(color + f"{symbol} {message}" + Style.RESET_ALL)
+
+
+def print_as_json(data):
+    print(json.dumps(data))
 
 
 def write_to_excel(data, file_name="output.xlsx"):

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ dnspython>= 2.2.1
 tldextract
 pandas
 openpyxl
+json

--- a/spoofy.py
+++ b/spoofy.py
@@ -107,9 +107,9 @@ def main():
     parser.add_argument(
         "-o",
         type=str,
-        choices=["stdout", "xls"],
+        choices=["stdout", "xls", "json"],
         default="stdout",
-        help="Output format: stdout or xls (default: stdout).",
+        help="Output format: stdout (optionally as json) or xls (default: stdout).",
     )
     parser.add_argument(
         "-t", type=int, default=4, help="Number of threads to use (default: 4)"
@@ -138,6 +138,9 @@ def main():
         threads.append(thread)
 
     domain_queue.join()
+
+    if args.o == "json" and results:
+        report.print_as_json(results)
 
     if args.o == "xls" and results:
         report.write_to_excel(results)


### PR DESCRIPTION
As all the data is already handled as dictionary, only a small addition is required to add JSON output. This can be beneficial for cases, in which you would like to further process the data (e.g. piping into `jq`) without having to parse the excel or stdout.