### PR TITLE
Add setup.py for pip/pipx compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@ from setuptools import setup
 setup(
     name="Spoofy",
     version="1.0.2",
+    packages=[ "modules", "files" ],
     install_requires=[ "colorama", "dnspython>= 2.2.1", "tldextract", "pandas", "openpyxl" ],
     entry_points={ "console_scripts": [ "spoofy=spoofy:main" ] }
 )

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@ setup(
     name="Spoofy",
     version="1.0.2",
     packages=[ "modules", "files" ],
+    py_modules=["spoofy"],
     install_requires=[ "colorama", "dnspython>= 2.2.1", "tldextract", "pandas", "openpyxl" ],
     entry_points={ "console_scripts": [ "spoofy=spoofy:main" ] }
 )

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,9 @@
+from setuptools import setup
+
+setup(
+    name="Spoofy",
+    version="1.0.2",
+    install_requires=[ "colorama", "dnspython>= 2.2.1", "tldextract", "pandas", "openpyxl" ],
+    entry_points={ "console_scripts": [ "spoofy=spoofy:main" ] }
+)
+


### PR DESCRIPTION
# Summary

This tool currently lacks a `setup.py`, making it impossible to install via pip or pipx. Personally I prefer using pipx to isolate Python tools in separate virtual environments. Please note that this change **does not** break or prevent installation via the old method of `pip install -r requirements.txt` / `python spoofy.py`.

# Changes:

- Added minimal `setup.py` with:
  - Dependency specification (`install_requires=[ "colorama", "dnspython>= 2.2.1", "tldextract", "pandas", "openpyxl" ]`).
  - Console script entry point (`entry_points={ "console_scripts": [ "spoofy=spoofy:main" ] }`).

# Example Usage:

```
pipx (or pip) install git+https://github.com/MattKeeley/Spoofy
spoofy -h
```
